### PR TITLE
Handle quick replies

### DIFF
--- a/app/bot/intents/classifier.rb
+++ b/app/bot/intents/classifier.rb
@@ -1,7 +1,8 @@
 module Intents
   class Classifier
-    def self.classify(text)
-      map_text_to_intent(text)
+    def self.classify(message)
+      return quick_reply(message)['payload'].to_sym if quick_reply(message)
+      map_text_to_intent(message.text)
     end
 
     private
@@ -15,6 +16,10 @@ module Intents
         elsif /white/i.match?(text)
           :add_white
         end
+      end
+
+      private def quick_reply(message)
+        message.messaging['message']['quick_reply']
       end
     end
   end

--- a/app/bot/intents/mapper.rb
+++ b/app/bot/intents/mapper.rb
@@ -1,11 +1,14 @@
 module Intents
   class Mapper
-    def self.map_intent_to_message(intent)
-      if intent == :create_account
+    def self.map_intent_to_message(intent, facebook_id: nil)
+      case intent
+      when :create_account
         create_account_message
-      elsif intent == :add_red
+      when :CREATE_ACCOUNT
+        handle_create_account_confirmation(facebook_id)
+      when :add_red
         add_red_message
-      elsif intent == :add_white
+      when :add_white
         add_white_message
       else
         fallback_message
@@ -18,6 +21,16 @@ module Intents
           message: {
             text: 'Would you like to create your account with Charles d\'Née?',
             quick_replies: account_creation_quick_replies
+          }
+        }
+      end
+
+      private def handle_create_account_confirmation(facebook_id)
+        data = Users::RetrieveUserData.call(facebook_id)
+        Users::FindOrCreateUser.call(user_data: data)
+        {
+          message: {
+            text: 'Great! You have successfully created an account with Charles d\'Née.',
           }
         }
       end

--- a/app/bot/request_handlers/message.rb
+++ b/app/bot/request_handlers/message.rb
@@ -1,20 +1,9 @@
 module RequestHandlers
   class Message
     def self.handle(message)
-      sender = message.sender
-      user_data = Users::RetrieveUserData.call(sender['id'])
-      intent = Intents::Classifier.classify(message.text)
-
+      intent = Intents::Classifier.classify(message)
       response_message = Intents::Mapper.map_intent_to_message(intent)
-      response_message[:recipient] = sender
-
-      if message.messaging['message']['quick_reply']
-        payload = message.messaging['message']['quick_reply']['payload']
-        if payload == 'CREATE_ACCOUNT'
-          response_message[:message][:text] = 'Great! You have successfully created an account with Charles d\'Née.'
-          ::Users::FindOrCreateUser.call(user_data: user_data)
-        end
-      end
+      response_message[:recipient] = message.sender
 
       Bot.deliver(response_message, access_token: ENV['FB_ACCESS_TOKEN'])
     end

--- a/spec/bot/intents/classifier_spec.rb
+++ b/spec/bot/intents/classifier_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Intents::Classifier do
-  FakeMessage = Struct.new(:sender, :recipient, :timestamp, :text, :messaging)
   describe '.classify' do
     it 'correctly classifies a message asking to create an account' do
       text = 'I\'d like to create an account please'
@@ -35,25 +34,5 @@ RSpec.describe Intents::Classifier do
 
       expect(intent).to eq(:just_anything_for_now)
     end
-  end
-
-  private
-
-  def fake_incoming_message(message_text, quick_reply_payload = nil)
-    sender = {"id"=>"1234"}
-    recipient = {"id"=>"5678"}
-    timestamp = 1528049653543
-    messaging = {
-      "sender"=>{"id"=>"1732016540208841"},
-        "recipient"=>{"id"=>"364376550736984"},
-        "timestamp"=>1535288528163,
-        "message"=>{
-          "mid"=> "0j3SQeNnpIDLxBwJl7hRofACd_36bJGN3qXKXv32Bok8GqJfA284e1hsnOagFiVZsbqLLainVGIVURWOlNJ4Tw",
-          "seq"=>2171281,
-          "text"=>"Account"
-        }
-      }
-    messaging['message']['quick_reply'] = {'payload' => quick_reply_payload} if quick_reply_payload
-    FakeMessage.new(sender, recipient, timestamp, message_text, messaging)
   end
 end

--- a/spec/bot/intents/classifier_spec.rb
+++ b/spec/bot/intents/classifier_spec.rb
@@ -1,26 +1,59 @@
 require 'rails_helper'
 
 RSpec.describe Intents::Classifier do
+  FakeMessage = Struct.new(:sender, :recipient, :timestamp, :text, :messaging)
   describe '.classify' do
     it 'correctly classifies a message asking to create an account' do
       text = 'I\'d like to create an account please'
-      intent = Intents::Classifier.classify(text)
+      message = fake_incoming_message(text)
+      intent = Intents::Classifier.classify(message)
 
       expect(intent).to eq(:create_account)
     end
 
     it 'correctly classifies a message asking to add a new bottle of red wine' do
       text = 'I just had a bottle of red'
-      intent = Intents::Classifier.classify(text)
+      message = fake_incoming_message(text)
+      intent = Intents::Classifier.classify(message)
 
       expect(intent).to eq(:add_red)
     end
 
     it 'correctly classifies a message asking to add a new bottle of white wine' do
       text = 'I just had a bottle of white'
-      intent = Intents::Classifier.classify(text)
+      message = fake_incoming_message(text)
+      intent = Intents::Classifier.classify(message)
 
       expect(intent).to eq(:add_white)
     end
+
+    it 'correctly classifies an incoming quick_reply' do
+      text = 'I just had a bottle of white'
+      quick_reply_payload = 'just_anything_for_now'
+      message = fake_incoming_message(text, quick_reply_payload)
+      intent = Intents::Classifier.classify(message)
+
+      expect(intent).to eq(:just_anything_for_now)
+    end
+  end
+
+  private
+
+  def fake_incoming_message(message_text, quick_reply_payload = nil)
+    sender = {"id"=>"1234"}
+    recipient = {"id"=>"5678"}
+    timestamp = 1528049653543
+    messaging = {
+      "sender"=>{"id"=>"1732016540208841"},
+        "recipient"=>{"id"=>"364376550736984"},
+        "timestamp"=>1535288528163,
+        "message"=>{
+          "mid"=> "0j3SQeNnpIDLxBwJl7hRofACd_36bJGN3qXKXv32Bok8GqJfA284e1hsnOagFiVZsbqLLainVGIVURWOlNJ4Tw",
+          "seq"=>2171281,
+          "text"=>"Account"
+        }
+      }
+    messaging['message']['quick_reply'] = {'payload' => quick_reply_payload} if quick_reply_payload
+    FakeMessage.new(sender, recipient, timestamp, message_text, messaging)
   end
 end

--- a/spec/bot/intents/mapper_spec.rb
+++ b/spec/bot/intents/mapper_spec.rb
@@ -2,13 +2,22 @@ require 'rails_helper'
 
 RSpec.describe Intents::Mapper do
   describe '.map_intent_to_message' do
-    it 'maps the :create_account intent to a message inviting the user to create an account' do
+    it 'maps the :create_account intent to a message inviting the user to create an account, with quick replies' do
       intent = :create_account
       message = Intents::Mapper.map_intent_to_message(intent)
 
       expect(message[:message][:text]).to include('create your account')
       expect(message[:message][:quick_replies]).to be_an_instance_of(Array)
       expect(message[:message][:quick_replies][0][:payload]).to eq('CREATE_ACCOUNT')
+    end
+
+    it 'maps the :CREATE_ACCOUNT intent to calling the create account service and returning an appropriate message' do
+      intent = :CREATE_ACCOUNT
+      expect(Users::RetrieveUserData).to receive(:call).with(1234) { 'user data' }
+      expect(Users::FindOrCreateUser).to receive(:call).with(user_data: 'user data')
+      message = Intents::Mapper.map_intent_to_message(intent, facebook_id: 1234)
+
+      expect(message[:message][:text]).to include('successfully created an account')
     end
 
     it 'maps the :add_red intent to a message inviting the user to add a bottle of red' do
@@ -25,7 +34,7 @@ RSpec.describe Intents::Mapper do
       expect(message[:message][:text]).to include('add a new bottle of white')
     end
 
-    it 'maps a nil intent to a geeric message' do
+    it 'maps a nil intent to a generic message' do
       intent = nil
       message = Intents::Mapper.map_intent_to_message(intent)
 

--- a/spec/bot/request_handlers/message_spec.rb
+++ b/spec/bot/request_handlers/message_spec.rb
@@ -1,18 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe RequestHandlers::Message do
-  FakeMessage = Struct.new(:sender, :recipient, :timestamp, :text, :messaging)
-
-  before(:each) do
-    stub_facebook_user_data_request
-  end
-
   describe '.handle' do
     it 'responds with a message' do
-      stub_deliver
+      expect_bot_message_to_have_text('It\'s Han, but that\'s okay')
       message = fake_incoming_message('Hello, world')
       expect(Intents::Classifier).to receive(:classify)
-      expect(Intents::Mapper).to receive(:map_intent_to_message) { fake_outgoing_message('Hello, world') }
+      expect(Intents::Mapper).to receive(:map_intent_to_message) { fake_outgoing_message('It\'s Han, but that\'s okay') }
 
       RequestHandlers::Message.handle(message)
     end
@@ -39,24 +33,6 @@ RSpec.describe RequestHandlers::Message do
 
   private
 
-  def fake_incoming_message(message_text, quick_reply_payload = nil)
-    sender = {"id"=>"1234"}
-    recipient = {"id"=>"5678"}
-    timestamp = 1528049653543
-    messaging = {
-      "sender"=>{"id"=>"1732016540208841"},
-        "recipient"=>{"id"=>"364376550736984"},
-        "timestamp"=>1535288528163,
-        "message"=>{
-          "quick_reply"=>{"payload"=>quick_reply_payload},
-          "mid"=> "0j3SQeNnpIDLxBwJl7hRofACd_36bJGN3qXKXv32Bok8GqJfA284e1hsnOagFiVZsbqLLainVGIVURWOlNJ4Tw",
-          "seq"=>2171281,
-          "text"=>"Account"
-        }
-      }
-    FakeMessage.new(sender, recipient, timestamp, message_text, messaging)
-  end
-
   def fake_outgoing_message(text, quick_replies = nil)
     {
       message: {
@@ -66,67 +42,12 @@ RSpec.describe RequestHandlers::Message do
     }
   end
 
-  def expect_bot_message_to_have_text(message, text)
+  def expect_bot_message_to_have_text(text)
     expect(Bot).to receive(:deliver)
       .with(
         hash_including(message: hash_including(text: text)),
         access_token: ENV['FB_ACCESS_TOKEN']
       )
-  end
-
-  def expect_bot_message_to_have_quick_reply(message, quick_reply)
-    expect(Bot).to receive(:deliver)
-      .with(
-        hash_including(
-          message: hash_including(
-            quick_replies: array_including(quick_reply)
-          )
-        ),
-        access_token: ENV['FB_ACCESS_TOKEN']
-      )
-
-      RequestHandlers::Message.handle(message)
-  end
-
-  def expect_bot_message_not_to_have_quick_replies(message)
-    expect(Bot).to receive(:deliver)
-      .with(
-        hash_including(
-          message: hash_excluding(
-            quick_replies: instance_of(Array)
-          )
-        ),
-        access_token: ENV['FB_ACCESS_TOKEN']
-      )
-
-      RequestHandlers::Message.handle(message)
-  end
-
-  def stub_facebook_user_data_request
-    stub_request(:get, facebook_user_data_request_url)
-      .with(facebook_user_data_request_headers)
-      .to_return(facebook_user_data_response)
-  end
-
-  def facebook_user_data_request_url
-    "https://graph.facebook.com/1234?fields=first_name,last_name,profile_pic&access_token=#{ENV['FB_ACCESS_TOKEN']}"
-  end
-
-  def facebook_user_data_request_headers
-    {headers: {'Accept'=>'*/*'}}
-  end
-
-  def facebook_user_data_response
-    {
-      status: 200,
-      body: {
-        "first_name" => "Peter",
-        "last_name" => "Johnstone",
-        "profile_pic" => "https://platform-lookaside.fbsbx.com/platform/profilepic/",
-        "id" => "1234"
-      }.to_json,
-      headers: {}
-    }
   end
 
   def stub_deliver

--- a/spec/bot/request_handlers/message_spec.rb
+++ b/spec/bot/request_handlers/message_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RequestHandlers::Message do
       allow(Intents::Mapper).to receive(:map_intent_to_message) { fake_outgoing_message(expected_response) }
 
       expect_bot_message_to_have_text(message, expected_response)
-      # expect_bot_message_not_to_have_quick_replies(message)
+      expect_bot_message_not_to_have_quick_replies(message)
 
       RequestHandlers::Message.handle(message)
     end

--- a/spec/helpers/test_helper.rb
+++ b/spec/helpers/test_helper.rb
@@ -1,0 +1,19 @@
+FakeMessage = Struct.new(:sender, :recipient, :timestamp, :text, :messaging)
+
+def fake_incoming_message(message_text, quick_reply_payload = nil)
+  sender = {"id"=>"1234"}
+  recipient = {"id"=>"5678"}
+  timestamp = 1528049653543
+  messaging = {
+    "sender"=>{"id"=>"1732016540208841"},
+      "recipient"=>{"id"=>"364376550736984"},
+      "timestamp"=>1535288528163,
+      "message"=>{
+        "mid"=> "0j3SQeNnpIDLxBwJl7hRofACd_36bJGN3qXKXv32Bok8GqJfA284e1hsnOagFiVZsbqLLainVGIVURWOlNJ4Tw",
+        "seq"=>2171281,
+        "text"=>"Account"
+      }
+    }
+  messaging['message']['quick_reply'] = {'payload' => quick_reply_payload} if quick_reply_payload
+  FakeMessage.new(sender, recipient, timestamp, message_text, messaging)
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'webmock/rspec'
 require 'factory_bot'
+require_relative './helpers/test_helper'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
This PR extracts the logic for handling incoming quick reply messages to the `Classifier` and `Mapper` classes. It also simplifies the tests, and creates a `test_helper.rb` with the beginnings of some helpful methods for test files. 
